### PR TITLE
Add Perl modules and a couple commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,38 +54,62 @@ RUN cpanm --notest --force \
 
 # packages which install properly
 RUN cpanm \
-  Archive::Zip \
   aliased \
+  Archive::Zip \
   Benchmark::Timer \
   Carp::Always \
+  Catalyst::Plugin::RunAfterRequest \
+  Catalyst::Plugin::SimpleCAS \
   CGI::Expand \
   Config::Settings \
+  Data::Dump \
+  Data::Dx \
+  Data::Printer \
+  Data::TableReader \
   DateTime \
   DateTime::Format::Duration \
   DateTime::Format::Flexible \
+  DateTime::Format::Flexible \
   DateTime::Format::Pg \
   DBD::Pg \
+  DBIx::Class::AuditAny \
   DBIx::Class::Candy \
   DBIx::Class::Cursor::Cached \
   DBIx::Class::Helper::Row::SelfResultSet \
   DBIx::Class::Helpers \
+  DBIx::Class::Helpers \
   DBIx::Class::QueryLog \
   DBIx::Class::ResultDDL \
-  DBIx::Class::TimeStamp \
-  DBIx::Class::AuditAny \
-  DBIx::Class::Helpers \
   DBIx::Class::Schema::Diff \
   DBIx::Class::StateMigrations \
   DBIx::Class::TimeStamp \
+  DBIx::Class::TimeStamp \
   Devel::Confess \
   Devel::DDCWarn \
+  Devel::NYTProf \
+  Digest::MD5 \
+  Digest::SHA1 \
+  Email::Address \
+  Email::MIME::CreateHTML \
+  Email::Sender \
+  Email::Valid \
+  HTML::Diff \
+  HTML::Diff \
+  HTML::Entities \
+  HTML::FormatText::WithLinks \
+  HTML::FromANSI \
   HTTP::Request \
   HTTP::Request::AsCGI \
   JSON \
+  JSON::XS \
   lib::relative \
   Lingua::EN::Nickname \
   Log::Any \
+  Log::Any \
+  Log::Any::Adapter::Daemontools \
+  Log::Any::Adapter::TAP \
   Log::Contextual::WarnLogger \
+  LWP::UserAgent \
   Math::PercentChange \
   Moo \
   Moose \
@@ -97,51 +121,27 @@ RUN cpanm \
   PadWalker \
   Parallel::ForkManager \
   Path::Class \
+  Plack::Builder \
   Plack::Middleware \
   RapidApp::Util \
-  String::TT \
-  Text::Trim \
-  Tie::Hash::Indexed \
-  Text::Trim \
-  Type::Tiny \
-  YAML \
-  HTML::Diff \
-  Catalyst::Plugin::RunAfterRequest \
-  Catalyst::Plugin::SimpleCAS \
-  Data::Dump \
-  Data::Dx \
-  Data::Printer \
-  Data::TableReader \
-  DateTime::Format::Flexible \
-  Devel::NYTProf \
-  Digest::MD5 \
-  Digest::SHA1 \
-  Email::Address \
-  Email::MIME::CreateHTML \
-  Email::Sender \
-  Email::Valid \
-  HTML::Diff \
-  HTML::Entities \
-  HTML::FormatText::WithLinks \
-  HTML::FromANSI \
-  JSON::XS \
-  LWP::UserAgent \
-  Log::Any \
-  Log::Any::Adapter::Daemontools \
-  Log::Any::Adapter::TAP \
-  Plack::Builder \
   Spreadsheet::ParseExcel \
   Spreadsheet::ParseXLSX \
   Starman \
+  String::TT \
   Term::ReadKey \
   Term::ReadLine \
   Term::Size::Any \
   Text::CSV_XS \
   Text::Password::Pronounceable \
   Text::Trim \
+  Text::Trim \
+  Text::Trim \
+  Tie::Hash::Indexed \
   Tie::Hash::Indexed \
   Try::Tiny \
+  Type::Tiny \
   WebService::Mattermost \
+  YAML \
   YAML::XS \
 && rm -rf ~/.cpanm/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,6 @@ RUN cpanm \
   DateTime \
   DateTime::Format::Duration \
   DateTime::Format::Flexible \
-  DateTime::Format::Flexible \
   DateTime::Format::Pg \
   DBD::Pg \
   DBIx::Class::AuditAny \
@@ -77,12 +76,10 @@ RUN cpanm \
   DBIx::Class::Cursor::Cached \
   DBIx::Class::Helper::Row::SelfResultSet \
   DBIx::Class::Helpers \
-  DBIx::Class::Helpers \
   DBIx::Class::QueryLog \
   DBIx::Class::ResultDDL \
   DBIx::Class::Schema::Diff \
   DBIx::Class::StateMigrations \
-  DBIx::Class::TimeStamp \
   DBIx::Class::TimeStamp \
   Devel::Confess \
   Devel::DDCWarn \
@@ -94,7 +91,6 @@ RUN cpanm \
   Email::Sender \
   Email::Valid \
   HTML::Diff \
-  HTML::Diff \
   HTML::Entities \
   HTML::FormatText::WithLinks \
   HTML::FromANSI \
@@ -104,7 +100,6 @@ RUN cpanm \
   JSON::XS \
   lib::relative \
   Lingua::EN::Nickname \
-  Log::Any \
   Log::Any \
   Log::Any::Adapter::Daemontools \
   Log::Any::Adapter::TAP \
@@ -134,9 +129,6 @@ RUN cpanm \
   Text::CSV_XS \
   Text::Password::Pronounceable \
   Text::Trim \
-  Text::Trim \
-  Text::Trim \
-  Tie::Hash::Indexed \
   Tie::Hash::Indexed \
   Try::Tiny \
   Type::Tiny \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ RUN cpanm \
   Data::Dx \
   Data::Printer \
   Data::TableReader \
+  Date::RetentionPolicy \
   DateTime \
   DateTime::Format::Duration \
   DateTime::Format::Flexible \
@@ -94,6 +95,7 @@ RUN cpanm \
   HTML::Entities \
   HTML::FormatText::WithLinks \
   HTML::FromANSI \
+  HTML::FromText \
   HTTP::Request \
   HTTP::Request::AsCGI \
   JSON \
@@ -109,6 +111,8 @@ RUN cpanm \
   Moo \
   Moose \
   MooseX::AttributeShortcuts \
+  MooseX::FileAttribute \
+  MooseX::SimpleConfig \
   MooseX::Types::LoadableClass \
   MooseX::Types::Moose \
   Net::LDAP \
@@ -116,6 +120,7 @@ RUN cpanm \
   PadWalker \
   Parallel::ForkManager \
   Path::Class \
+  PDF::API2 \
   Plack::Builder \
   Plack::Middleware \
   RapidApp::Util \
@@ -126,9 +131,11 @@ RUN cpanm \
   Term::ReadKey \
   Term::ReadLine \
   Term::Size::Any \
+  Test::Postgresql58 \
   Text::CSV_XS \
   Text::Password::Pronounceable \
   Text::Trim \
+  Tie::FS \
   Tie::Hash::Indexed \
   Try::Tiny \
   Type::Tiny \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,11 @@ RUN apt-get -y upgrade
 
 # Install additional packages of interest.
 RUN apt-get -y install \
+  colordiff \
   less \
   man-db \
   postgresql-common \
+  strace \
 && :
 
 # Setup PostgreSQL apt repository.

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,4 +144,6 @@ RUN cpanm \
   YAML::XS \
 && rm -rf ~/.cpanm/
 
+RUN cpanm Data::TableReader::Decoder::HTML || (cd ~/.cpanm/latest-build/Data-TableReader-Decoder-HTML-0.010 && perl -pi -e 's/\b0\.09\b/0.009/g' META.json META.yml MYMETA.json MYMETA.yml Makefile Makefile.PL dist.ini && perl Makefile.PL && make && make test && make install)
+
 RUN cpanm http://www.cpan.org/authors/id/V/VA/VANSTYN/DBIC-Violator-0.900.tar.gz && rm -rf .cpanm/


### PR DESCRIPTION
This pull request sorts the list of Perl modules, eliminates 8 duplicates from that list, adds 8 new modules (one with a special-case fix to work around a bug in the CPAN distribution), and also adds the "colordiff" and "strace" Linux commands.